### PR TITLE
Added support for QLogic adapter

### DIFF
--- a/netdev.sh
+++ b/netdev.sh
@@ -8,3 +8,8 @@ for pciaddress in $(${lshwcmd} -C Network 2>/dev/null | grep "pci@" | awk -F":" 
 do
     ${lspcicmd} -v -s ${pciaddress} | grep "Subsystem" | awk -F":" '{print $2}'| xargs;
 done
+# support for QLogic and Emulex HBA Adapter
+${lspcicmd} -nn | grep -Ei 'hba|host bus adapter|fibre channel' | awk -F" " '{print $1}' | while read pciaddress;
+do
+    ${lspcicmd} -v -s ${pciaddress} | grep "Subsystem" | awk -F":" '{print $2}'| xargs;
+done

--- a/netdriver.sh
+++ b/netdriver.sh
@@ -8,3 +8,8 @@ for pciaddress in $(${lshwcmd} -C Network 2>/dev/null | grep "pci@" | awk -F":" 
 do
     ${lspcicmd} -v -s ${pciaddress} | grep "Kernel driver" | awk -F":" '{print $2}' | xargs;
 done
+# support for QLogic and Emulex HBA Adapter
+${lspcicmd} -nn | grep -Ei 'hba|host bus adapter|fibre channel' | awk -F" " '{print $1}' | while read pciaddress;
+do
+    ${lspcicmd} -v -s ${pciaddress} | grep "Kernel driver" | awk -F":" '{print $2}'| xargs;
+done

--- a/netversions.sh
+++ b/netversions.sh
@@ -17,3 +17,15 @@ if [ -z "${versionstring}" ]
         echo ${versionstring}
     fi
 done
+# support for QLogic and Emulex HBA Adapter
+${lspcicmd} -nn | grep -Ei 'hba|host bus adapter|fibre channel' | awk -F" " '{print $1}' | while read pciaddress;
+do
+    hbaversionstring=`${lspcicmd} -v -s ${pciaddress} | grep "Kernel driver" | awk -F":" '{print $2}' | xargs ${modinfocmd} 2>/dev/null | grep ^version: | awk '{print $2}'`
+    if [ -z "${hbaversionstring}" ]
+    then
+        echo `${lspcicmd} -v -s ${pciaddress} | grep "Kernel driver" | awk -F":" '{print $2}'| \
+    xargs ${modinfocmd} 2>/dev/null | grep ^vermagic: | awk '{print $2}'`
+    else
+        echo ${hbaversionstring}
+    fi
+done


### PR DESCRIPTION
Output from server:

```
[root@rhel88 os-discovery-tool]# lspci -nn | grep -Ei 'Fibre Channel'
19:00.0 Fibre Channel [0c04]: QLogic Corp. ISP2722-based 16/32Gb Fibre Channel to PCIe Adapter [1077:2261] (rev 01)
```
to find QLogic adapter details, we have to filter 'Fibre Channel' in lspci utility output.