### PR TITLE
use rocm driver version for amdgpu

### DIFF
--- a/gpudev.sh
+++ b/gpudev.sh
@@ -7,7 +7,7 @@ lspcicmd=`which lspci`
 gpuvendornvidia='nvidia'
 gpuvendoramd='amd'
 nvidiasmicmd=`which nvidia-smi 2>&1`
-amdsmicmd=`which amd-smi 2>&1`
+amdcmdpath="/opt/rocm/.info/version"
 invalid=" |'"
 
 for pciaddress in $(${lshwcmd} -C Display 2>/dev/null | grep "pci@" | awk -F":" '{print $3":"$4}');
@@ -20,7 +20,7 @@ do
         fi
     # AMD Vendor GPU
     elif [[ ${displaydevice,,} =~ ${gpuvendoramd} ]]; then
-        if ! ([[ $amdsmicmd =~ $invalid || -z "$amdsmicmd" ]]); then
+        if [ -e $amdcmdpath ]; then
             echo $displaydevice
         fi
     fi

--- a/gpudriver.sh
+++ b/gpudriver.sh
@@ -7,7 +7,7 @@ lspcicmd=`which lspci`
 modinfocmd=`which modinfo`
 osvendor=$(cat /etc/*-release 2>/dev/null | grep -i ^ID= | head -n1 | awk -F"=" '{print $2}'| xargs)
 nvidiasmicmd=`which nvidia-smi 2>&1`
-amdsmicmd=`which amd-smi 2>&1`
+amdcmdpath="/opt/rocm/.info/version"
 invalid=" |'"
 
 # List of OS vendors who support nvidia drivers
@@ -72,10 +72,8 @@ for pciaddress in $(${lshwcmd} -C Display 2>/dev/null | grep "pci@" | awk -F":" 
             continue
          fi
     elif [[ ${displaydevice,,} =~ 'amd' ]]; then
-        if ! ([[ $amdsmicmd =~ $invalid || -z "$amdsmicmd" ]]); then
-            amdgpudriver=$(${lspcicmd} -v -s ${pciaddress} | grep "Kernel driver" | awk -F":" '{print $2}' | xargs);
-            amdgpuversion=$(${lspcicmd} -v -s ${pciaddress} | grep "Kernel driver" | awk -F":" '{print $2}' | xargs ${modinfocmd} 2>/dev/null | grep -i "version" | head -n1 | awk '{print $2}' | xargs)
-	    echo "${amdgpudriver}"
+        if [ -e $amdcmdpath ]; then
+	    echo "rocm"
         fi
     fi
 done

--- a/gpuversions.sh
+++ b/gpuversions.sh
@@ -7,7 +7,7 @@ lspcicmd=`which lspci`
 modinfocmd=`which modinfo`
 osvendor=$(cat /etc/*-release 2>/dev/null | grep -i ^ID= | head -n1 | awk -F"=" '{print $2}'| xargs)
 nvidiasmicmd=`which nvidia-smi 2>&1`
-amdsmicmd=`which amd-smi 2>&1`
+amdcmdpath="/opt/rocm/.info/version"
 invalid=" |'"
 
 # List of OS vendors who support nvidia drivers
@@ -72,10 +72,8 @@ for pciaddress in $(${lshwcmd} -C Display 2>/dev/null | grep "pci@" | awk -F":" 
             continue
          fi
     elif [[ ${displaydevice,,} =~ 'amd' ]]; then
-        if ! ([[ $amdsmicmd =~ $invalid || -z "$amdsmicmd" ]]); then
-            amdgpudriver=$(${lspcicmd} -v -s ${pciaddress} | grep "Kernel driver" | awk -F":" '{print $2}' | xargs);
-            amdgpuversion=$(${lspcicmd} -v -s ${pciaddress} | grep "Kernel driver" | awk -F":" '{print $2}' | xargs ${modinfocmd} 2>/dev/null | grep -i "version" | head -n1 | awk '{print $2}' | xargs)
-	    echo "${amdgpuversion}"
+        if [ -e $amdcmdpath ]; then
+	    cat $amdcmdpath
         fi
     fi
 done


### PR DESCRIPTION
Earlier we used to track amd-smi version for amdgpu but AMD confirmed that we have to track rocm driver version for amdgpu and hence necessary changes were made.

sample output:
```
 -kv:
  key: os.driver.10.name
  value: rocm
 -kv:
  key: os.driver.10.version
  value: 6.3.2-66
 -kv:
  key: os.driver.10.description
  value: Advanced Micro Devices, Inc. [AMD/ATI] Device 0c34
```