### PR TITLE
handled error msg change of nvidia gpu

### DIFF
--- a/gpudriver.sh
+++ b/gpudriver.sh
@@ -56,10 +56,11 @@ for pciaddress in $(${lshwcmd} -C Display 2>/dev/null | grep "pci@" | awk -F":" 
                   fi
 
               else
-                if [[ (${osvendorlist[*]} =~ ${osvendor}) ]] && [[ ($nvidiavgpu == "Not supported devices in vGPU mode")]];
+                pattern="^No[t]? supported devices in vGPU mode$"
+                if [[ (${osvendorlist[*]} =~ ${osvendor}) ]] && echo "$nvidiavgpu" | grep -Eq "$pattern";
                     then
                     echo "${driver}(compute)"
-                elif [[ ($osvendor == "rhel") || ($osvendor == "red hat") ]] && [[ !($nvidiavgpu == "Not supported devices in vGPU mode") ]];
+                elif [[ ($osvendor == "rhel") || ($osvendor == "red hat") ]] && ! (echo "$nvidiavgpu" | grep -Eq "$pattern");
                     then
                     echo "${driver}(graphics)"
                  fi

--- a/gpuversions.sh
+++ b/gpuversions.sh
@@ -56,10 +56,11 @@ for pciaddress in $(${lshwcmd} -C Display 2>/dev/null | grep "pci@" | awk -F":" 
                   fi
 
               else
-                if [[ (${osvendorlist[*]} =~ ${osvendor}) ]] && [[ ($nvidiavgpu == "Not supported devices in vGPU mode")]];
+                pattern="^No[t]? supported devices in vGPU mode$"
+                if [[ (${osvendorlist[*]} =~ ${osvendor}) ]] && echo "$nvidiavgpu" | grep -Eq "$pattern";
                     then
                     echo "${nvidiagpuversion}"
-                elif [[ ($osvendor == "rhel") || ($osvendor == "red hat") ]] && [[ !($nvidiavgpu == "Not supported devices in vGPU mode") ]];
+                elif [[ ($osvendor == "rhel") || ($osvendor == "red hat") ]] && ! (echo "$nvidiavgpu" | grep -Eq "$pattern");
                     then
                     echo "${nvidiagpuversion}"
                  fi


### PR DESCRIPTION
Error message changed in nvidia-smi command output which caused issue in identifying the driver name.
In earlier drivers the error message was `Not supported devices in vGPU mode` and currently it got changed to `No supported devices in vGPU mode`.
FIX: handled both the cases
Example output from server:

```
[root@rhel94 os-discovery-tool]# nvidia-smi vgpu
No supported devices in vGPU mode
```