### PR TITLE
Fix for Mellanox driver name and version empty

### DIFF
--- a/.github/workflows/dev-workflow.yml
+++ b/.github/workflows/dev-workflow.yml
@@ -17,6 +17,9 @@ jobs:
             - name: Replace version in RPM spec so correct source is downloaded when building RPM
               run: sed -Ei 's/(^Version:[[:space:]]*).*/\1${{github.run_number}}/' ${{ github.event.repository.name }}.spec
 
+            - name: Replace version in source files
+              run: sed -Ei 's/ucsToolVersion=""/ucsToolVersion="${{github.run_number}}"/' gather_inventory_from_host.sh
+
             - name: Create source archive
               run: tar -cvf ${{ env.RPMNAME }}-${{ github.run_number }}.tar.gz *
 
@@ -36,6 +39,9 @@ jobs:
 
             - name: Replace version in RPM spec so correct source is downloaded when building RPM
               run: sed -Ei 's/(^Version:[[:space:]]*).*/\1${{github.run_number}}/' ${{ github.event.repository.name }}.spec
+
+            - name: Replace version in source files
+              run: sed -Ei 's/ucsToolVersion=""/ucsToolVersion="${{github.run_number}}"/' gather_inventory_from_host.sh
 
             - name: Run rpmbuild on RPM spec to produce package
               id: rpm

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -19,6 +19,9 @@ jobs:
             - name: Replace version in RPM spec so correct source is downloaded when building RPM
               run: sed -Ei 's/(^Version:[[:space:]]*).*/\1${{github.ref_name}}/' ${{ github.event.repository.name }}.spec
 
+            - name: Replace version in source files
+              run: sed -Ei 's/ucsToolVersion=""/ucsToolVersion="${{github.ref_name}}"/' gather_inventory_from_host.sh
+
             - name: Create source archive
               run: tar -cvf ${{ env.RPMNAME }}-${{ github.ref_name }}.tar.gz *
 
@@ -38,6 +41,9 @@ jobs:
 
             - name: Replace version in RPM spec so correct source is downloaded when building RPM
               run: sed -Ei 's/(^Version:[[:space:]]*).*/\1${{github.ref_name}}/' ${{ github.event.repository.name }}.spec
+
+            - name: Replace version in source files
+              run: sed -Ei 's/ucsToolVersion=""/ucsToolVersion="${{github.ref_name}}"/' gather_inventory_from_host.sh
 
             - name: Run rpmbuild on RPM spec to produce package
               id: rpm

--- a/gather_inventory_from_host.sh
+++ b/gather_inventory_from_host.sh
@@ -3,6 +3,7 @@
 
 export PATH=$PATH:/sbin:/usr/sbin
 installationPath="/opt/os-discovery-tool"
+ucsToolVersion=""
 
 cleanup_host-inv()
 {
@@ -62,6 +63,10 @@ write-osinfo()
 	vendor=$os_vendor
 	name=$os_name
 	arch=$os_arch
+
+	echo " -kv:" >> $filename
+	echo "  key: os.ucsToolVersion" >> $filename
+	echo "  value:" $ucsToolVersion >> $filename
 
 	echo " -kv:" >> $filename
 	echo "  key: os.updateTimestamp" >> $filename

--- a/netdriver.sh
+++ b/netdriver.sh
@@ -6,7 +6,14 @@ lshwcmd=`which lshw`
 lspcicmd=`which lspci`
 for pciaddress in $(${lshwcmd} -C Network 2>/dev/null | grep "pci@" | awk -F":" '{print $3":"$4}');
 do
-    ${lspcicmd} -v -s ${pciaddress} | grep "Kernel driver" | awk -F":" '{print $2}' | xargs;
+    pcioutput=$("$lspcicmd" -v -s "$pciaddress")
+    kernel_driver=$(echo "$pcioutput" | grep "Kernel driver" | awk '{print $NF}')
+    kernel_modules=$(echo "$pcioutput" | grep "Kernel modules" | awk '{print $NF}')
+    if [ -n "$kernel_driver" ]; then
+        echo $kernel_driver
+    else
+        echo $kernel_modules
+    fi
 done
 # support for QLogic and Emulex HBA Adapter
 ${lspcicmd} -nn | grep -Ei 'hba|host bus adapter|fibre channel' | awk -F" " '{print $1}' | while read pciaddress;

--- a/netversions.sh
+++ b/netversions.sh
@@ -7,14 +7,20 @@ lspcicmd=`which lspci`
 modinfocmd=`which modinfo`
 for pciaddress in $(${lshwcmd} -C Network 2>/dev/null | grep "pci@" | awk -F":" '{print $3":"$4}');
 do
-    versionstring=`${lspcicmd} -v -s $pciaddress | grep "Kernel driver" | \
-    awk -F":" '{print $2}' | xargs ${modinfocmd} 2>/dev/null | grep ^version: | head -n1 | awk '{print $2}' | xargs`
-if [ -z "${versionstring}" ]
-    then
-        echo `${lspcicmd} -v -s $pciaddress | grep "Kernel driver" | awk -F":" '{print $2}' | \
-    xargs ${modinfocmd} 2>/dev/null | grep ^vermagic: | awk '{print $2}'`
+    pcioutput=$("$lspcicmd" -v -s "$pciaddress")
+    kernel_driver=$(echo "$pcioutput" | grep "Kernel driver" | awk '{print $NF}')
+    kernel_modules=$(echo "$pcioutput" | grep "Kernel modules" | awk '{print $NF}')
+    if [ -n "$kernel_driver" ]; then
+        kernel_info=$kernel_driver
     else
-        echo ${versionstring}
+        kernel_info=$kernel_modules
+    fi
+    version=$(${modinfocmd} $kernel_info 2>/dev/null | grep ^version: | head -n1 | awk '{print $2}' | xargs)
+    vermagic=$(${modinfocmd} $kernel_info 2>/dev/null | grep ^vermagic: | awk '{print $2}' | xargs)
+    if [ -n "${version}" ]; then
+        echo $version
+    else
+        echo $vermagic
     fi
 done
 # support for QLogic and Emulex HBA Adapter


### PR DESCRIPTION
**Issue:**
Mellanox adapter version is missing in the host-inv.yaml file.

**Root cause:**
Key name in the lspci output changed from `Kernel driver` to `Kernel modules` which caused the issue.

**e.g:**
```
[root@localhost os-discovery-tool]# lspci -v -s b4:00.0
b4:00.0 Ethernet controller: Mellanox Technologies MT43244 BlueField-3 integrated ConnectX-7 network controller (rev 01)
	Subsystem: Mellanox Technologies Device 0022
	Physical Slot: 109
	Flags: bus master, fast devsel, latency 0, IRQ 255, NUMA node 1
	Memory at 233ffa000000 (64-bit, prefetchable) [size=32M]
	Memory at 233ffc800000 (64-bit, prefetchable) [size=8M]
	Expansion ROM at dd200000 [disabled] [size=1M]
	Capabilities: [60] Express Endpoint, MSI 00
	Capabilities: [48] Vital Product Data
	Capabilities: [9c] MSI-X: Enable- Count=64 Masked-
	Capabilities: [c0] Vendor Specific Information: Len=18 <?>
	Capabilities: [40] Power Management version 3
	Capabilities: [100] Advanced Error Reporting
	Capabilities: [150] Alternative Routing-ID Interpretation (ARI)
	Capabilities: [180] Single Root I/O Virtualization (SR-IOV)
	Capabilities: [1c0] Secondary PCI Express
	Capabilities: [230] Access Control Services
	Capabilities: [240] Precision Time Measurement
	Capabilities: [320] Lane Margining at the Receiver <?>
	Capabilities: [370] Physical Layer 16.0 GT/s <?>
	Capabilities: [3b0] Extended Capability ID 0x2a
	Capabilities: [420] Data Link Feature <?>
	Kernel modules: mlx5_core
```
**Fix:** if `Kernel driver` not available, then data is fetched from `Kernel modules`

**sample output:**
```
 -kv:
  key: os.driver.4.name
  value: mlx5_core
 -kv:
  key: os.driver.4.version
  value: 24.10-1.1.4
 -kv:
  key: os.driver.4.description
  value: Mellanox Technologies Device 0022
```