### PR TITLE
send ucstoolversion as part of host-inv.yaml file

### DIFF
--- a/.github/workflows/dev-workflow.yml
+++ b/.github/workflows/dev-workflow.yml
@@ -15,7 +15,7 @@ jobs:
               uses: actions/checkout@v2
 
             - name: Replace version in source files
-              run: sed -Ei 's/ucsToolVersion=""$/ucsToolVersion="${{github.run_number}}"/' gather_inventory_from_host.sh
+              run: sed -Ei 's/@@RPM_VERSION@@$/${{github.run_number}}/' gather_inventory_from_host.sh
 
             - name: Replace version in RPM spec so correct source is downloaded when building RPM
               run: sed -Ei 's/(^Version:[[:space:]]*).*/\1${{github.run_number}}/' ${{ github.event.repository.name }}.spec
@@ -36,9 +36,6 @@ jobs:
         steps:
             - name: Checkout repository
               uses: actions/checkout@v2
-
-            - name: Replace version in source files
-              run: sed -Ei 's/ucsToolVersion=""$/ucsToolVersion="${{github.run_number}}"/' gather_inventory_from_host.sh
 
             - name: Replace version in RPM spec so correct source is downloaded when building RPM
               run: sed -Ei 's/(^Version:[[:space:]]*).*/\1${{github.run_number}}/' ${{ github.event.repository.name }}.spec

--- a/.github/workflows/dev-workflow.yml
+++ b/.github/workflows/dev-workflow.yml
@@ -15,7 +15,7 @@ jobs:
               uses: actions/checkout@v2
 
             - name: Replace version in source files
-              run: sed -Ei 's/@@RPM_VERSION@@$/${{github.run_number}}/' gather_inventory_from_host.sh
+              run: sed -Ei 's/@@VERSION@@/${{github.run_number}}/' gather_inventory_from_host.sh
 
             - name: Replace version in RPM spec so correct source is downloaded when building RPM
               run: sed -Ei 's/(^Version:[[:space:]]*).*/\1${{github.run_number}}/' ${{ github.event.repository.name }}.spec

--- a/.github/workflows/dev-workflow.yml
+++ b/.github/workflows/dev-workflow.yml
@@ -14,11 +14,11 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@v2
 
-            - name: Replace version in RPM spec so correct source is downloaded when building RPM
-              run: sed -Ei 's/(^Version:[[:space:]]*).*/\1${{github.run_number}}/' ${{ github.event.repository.name }}.spec
-
             - name: Replace version in source files
               run: sed -Ei 's/ucsToolVersion=""$/ucsToolVersion="${{github.run_number}}"/' gather_inventory_from_host.sh
+
+            - name: Replace version in RPM spec so correct source is downloaded when building RPM
+              run: sed -Ei 's/(^Version:[[:space:]]*).*/\1${{github.run_number}}/' ${{ github.event.repository.name }}.spec
 
             - name: Create source archive
               run: tar -cvf ${{ env.RPMNAME }}-${{ github.run_number }}.tar.gz *
@@ -37,11 +37,11 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@v2
 
-            - name: Replace version in RPM spec so correct source is downloaded when building RPM
-              run: sed -Ei 's/(^Version:[[:space:]]*).*/\1${{github.run_number}}/' ${{ github.event.repository.name }}.spec
-
             - name: Replace version in source files
               run: sed -Ei 's/ucsToolVersion=""$/ucsToolVersion="${{github.run_number}}"/' gather_inventory_from_host.sh
+
+            - name: Replace version in RPM spec so correct source is downloaded when building RPM
+              run: sed -Ei 's/(^Version:[[:space:]]*).*/\1${{github.run_number}}/' ${{ github.event.repository.name }}.spec
 
             - name: Run rpmbuild on RPM spec to produce package
               id: rpm

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -17,7 +17,7 @@ jobs:
               uses: actions/checkout@v2
 
             - name: Replace version in source files
-              run: sed -Ei 's/ucsToolVersion=""$/ucsToolVersion="${{github.ref_name}}"/' gather_inventory_from_host.sh
+              run: sed -Ei 's/@@RPM_VERSION@@$/${{github.run_number}}/' gather_inventory_from_host.sh
 
             - name: Replace version in RPM spec so correct source is downloaded when building RPM
               run: sed -Ei 's/(^Version:[[:space:]]*).*/\1${{github.ref_name}}/' ${{ github.event.repository.name }}.spec
@@ -38,9 +38,6 @@ jobs:
         steps:
             - name: Checkout repository
               uses: actions/checkout@v2
-
-            - name: Replace version in source files
-              run: sed -Ei 's/ucsToolVersion=""$/ucsToolVersion="${{github.ref_name}}"/' gather_inventory_from_host.sh
 
             - name: Replace version in RPM spec so correct source is downloaded when building RPM
               run: sed -Ei 's/(^Version:[[:space:]]*).*/\1${{github.ref_name}}/' ${{ github.event.repository.name }}.spec

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -16,11 +16,11 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@v2
 
-            - name: Replace version in RPM spec so correct source is downloaded when building RPM
-              run: sed -Ei 's/(^Version:[[:space:]]*).*/\1${{github.ref_name}}/' ${{ github.event.repository.name }}.spec
-
             - name: Replace version in source files
               run: sed -Ei 's/ucsToolVersion=""$/ucsToolVersion="${{github.ref_name}}"/' gather_inventory_from_host.sh
+
+            - name: Replace version in RPM spec so correct source is downloaded when building RPM
+              run: sed -Ei 's/(^Version:[[:space:]]*).*/\1${{github.ref_name}}/' ${{ github.event.repository.name }}.spec
 
             - name: Create source archive
               run: tar -cvf ${{ env.RPMNAME }}-${{ github.ref_name }}.tar.gz *
@@ -39,11 +39,11 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@v2
 
-            - name: Replace version in RPM spec so correct source is downloaded when building RPM
-              run: sed -Ei 's/(^Version:[[:space:]]*).*/\1${{github.ref_name}}/' ${{ github.event.repository.name }}.spec
-
             - name: Replace version in source files
               run: sed -Ei 's/ucsToolVersion=""$/ucsToolVersion="${{github.ref_name}}"/' gather_inventory_from_host.sh
+
+            - name: Replace version in RPM spec so correct source is downloaded when building RPM
+              run: sed -Ei 's/(^Version:[[:space:]]*).*/\1${{github.ref_name}}/' ${{ github.event.repository.name }}.spec
 
             - name: Run rpmbuild on RPM spec to produce package
               id: rpm

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -17,7 +17,7 @@ jobs:
               uses: actions/checkout@v2
 
             - name: Replace version in source files
-              run: sed -Ei 's/@@RPM_VERSION@@$/${{github.run_number}}/' gather_inventory_from_host.sh
+              run: sed -Ei 's/@@VERSION@@/${{github.run_number}}/' gather_inventory_from_host.sh
 
             - name: Replace version in RPM spec so correct source is downloaded when building RPM
               run: sed -Ei 's/(^Version:[[:space:]]*).*/\1${{github.ref_name}}/' ${{ github.event.repository.name }}.spec

--- a/gather_inventory_from_host.sh
+++ b/gather_inventory_from_host.sh
@@ -3,7 +3,7 @@
 
 export PATH=$PATH:/sbin:/usr/sbin
 installationPath="/opt/os-discovery-tool"
-ucsToolVersion="@@RPM_VERSION@@"
+ucsToolVersion="@@VERSION@@"
 
 cleanup_host-inv()
 {

--- a/gather_inventory_from_host.sh
+++ b/gather_inventory_from_host.sh
@@ -3,7 +3,7 @@
 
 export PATH=$PATH:/sbin:/usr/sbin
 installationPath="/opt/os-discovery-tool"
-ucsToolVersion=""
+ucsToolVersion="@@RPM_VERSION@@"
 
 cleanup_host-inv()
 {

--- a/os-discovery-tool-linux.spec
+++ b/os-discovery-tool-linux.spec
@@ -16,7 +16,7 @@ The Cisco Intersight os-discovery-tool is used to collect operating system and d
 %setup -q
 
 # Replace the placeholder in gather_inventory_from_host.sh with the actual RPM Version
-sed -i "s|@@RPM_VERSION@@|%{version}|g" gather_inventory_from_host.sh
+sed -i "s|@@VERSION@@|%{version}|g" gather_inventory_from_host.sh
 
 %build
 

--- a/os-discovery-tool-linux.spec
+++ b/os-discovery-tool-linux.spec
@@ -15,6 +15,9 @@ The Cisco Intersight os-discovery-tool is used to collect operating system and d
 %prep
 %setup -q
 
+# Replace the placeholder in gather_inventory_from_host.sh with the actual RPM Version
+sed -i "s|@@RPM_VERSION@@|%{version}|g" gather_inventory_from_host.sh
+
 %build
 
 %install


### PR DESCRIPTION
ODT RPM creates the host-inv.yaml file similar to the ESXI output, but it is missing the version information. This change  implements the gathering of version information during RPM generation and include it as part of the source file, so that it can be specified during the generation of the host-inv.yaml file.