### PR TITLE
Renamed output from os-discovery-tool to ucs-tool

### DIFF
--- a/.github/workflows/dev-workflow.yml
+++ b/.github/workflows/dev-workflow.yml
@@ -4,7 +4,7 @@ on: push
 env:
   DIST: el9
   ARCH: x86_64
-  RPMNAME: os-discovery-tool
+  RPMNAME: ucs-tool
 
 jobs:
     build_tarball:

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -6,7 +6,7 @@ on:
 env:
   DIST: el9
   ARCH: x86_64
-  RPMNAME: os-discovery-tool
+  RPMNAME: ucs-tool
 
 jobs:
     build_tarball:

--- a/README.md
+++ b/README.md
@@ -38,11 +38,11 @@ Confirm all pre-requisite packages are installed
 
 To install on Debain based systems:
 - Download the latest debain package from the releases page
-- Copy the debain package into the system and run the command ```dpkg -i <os-discovery-tool><version>.deb```
+- Copy the debain package into the system and run the command ```dpkg -i <ucs-tool><version>.deb```
 
 To install on RPM based systems:
 - Download the latest rpm package from the releases page
-- Copy the rpm package into the system and run the command ```rpm -i <os-discovery-tool><version>.rpm```
+- Copy the rpm package into the system and run the command ```rpm -i <ucs-tool><version>.rpm```
 
 A cron job to run at boot and preferably every 24 hours.
 

--- a/gather_inventory_from_host.sh
+++ b/gather_inventory_from_host.sh
@@ -2,7 +2,7 @@
 # Copyright (c) 2025 Cisco Systems, Inc. All rights reserved.
 
 export PATH=$PATH:/sbin:/usr/sbin
-installationPath="/opt/os-discovery-tool"
+installationPath="/opt/ucs-tool"
 ucsToolVersion="@@VERSION@@"
 
 cleanup_host-inv()

--- a/os-discovery-tool-linux.spec
+++ b/os-discovery-tool-linux.spec
@@ -1,14 +1,14 @@
-Name:           os-discovery-tool
+Name:           ucs-tool
 Version:        1.0.1
 Release:        1%{?dist}
 Vendor:         Cisco Systems, Inc.
-Summary:        The Cisco Intersight os-discovery-tool is used to collect operating system and driver information for Hardware Compliance Validation.
+Summary:        The Cisco Intersight ucs-tool is used to collect operating system and driver information for Hardware Compliance Validation.
 License:        Apache-2.0
 Source0:        %{name}-%{version}.tar.gz
 Requires:       bash, ipmitool
 
 %description
-The Cisco Intersight os-discovery-tool is used to collect operating system and driver information for Hardware Compliance Validation.
+The Cisco Intersight ucs-tool is used to collect operating system and driver information for Hardware Compliance Validation.
 
 %global debug_package %{nil}
 
@@ -22,48 +22,48 @@ sed -i "s|@@VERSION@@|%{version}|g" gather_inventory_from_host.sh
 
 %install
 rm -rf $RPM_BUILD_ROOT
-install -d $RPM_BUILD_ROOT/opt/os-discovery-tool
-install debian-os-name.sh $RPM_BUILD_ROOT/opt/os-discovery-tool/debian-os-name.sh
-install debian-os-version.sh $RPM_BUILD_ROOT/opt/os-discovery-tool/debian-os-version.sh
-install fcdev.sh $RPM_BUILD_ROOT/opt/os-discovery-tool/fcdev.sh
-install fcdriver.sh $RPM_BUILD_ROOT/opt/os-discovery-tool/fcdriver.sh
-install fcversions.sh $RPM_BUILD_ROOT/opt/os-discovery-tool/fcversions.sh
-install gather_inventory_from_host.sh $RPM_BUILD_ROOT/opt/os-discovery-tool/gather_inventory_from_host.sh
-install gpudev.sh $RPM_BUILD_ROOT/opt/os-discovery-tool/gpudev.sh
-install gpudriver.sh $RPM_BUILD_ROOT/opt/os-discovery-tool/gpudriver.sh
-install gpuversions.sh $RPM_BUILD_ROOT/opt/os-discovery-tool/gpuversions.sh
-install netdev.sh $RPM_BUILD_ROOT/opt/os-discovery-tool/netdev.sh
-install netdriver.sh $RPM_BUILD_ROOT/opt/os-discovery-tool/netdriver.sh
-install netversions.sh $RPM_BUILD_ROOT/opt/os-discovery-tool/netversions.sh
-install osvendor-legacy.sh $RPM_BUILD_ROOT/opt/os-discovery-tool/osvendor-legacy.sh
-install osvendor.sh $RPM_BUILD_ROOT/opt/os-discovery-tool/osvendor.sh
-install redhat-os-name.sh $RPM_BUILD_ROOT/opt/os-discovery-tool/redhat-os-name.sh
-install send_inventory_to_imc.sh $RPM_BUILD_ROOT/opt/os-discovery-tool/send_inventory_to_imc.sh
-install storagedev.sh $RPM_BUILD_ROOT/opt/os-discovery-tool/storagedev.sh
-install storagedriver.sh $RPM_BUILD_ROOT/opt/os-discovery-tool/storagedriver.sh
-install storageversions.sh $RPM_BUILD_ROOT/opt/os-discovery-tool/storageversions.sh
-install rocky-os-name.sh $RPM_BUILD_ROOT/opt/os-discovery-tool/rocky-os-name.sh
-install oracle-os-name.sh $RPM_BUILD_ROOT/opt/os-discovery-tool/oracle-os-name.sh
-install oracle-os-version.sh $RPM_BUILD_ROOT/opt/os-discovery-tool/oracle-os-version.sh
-install suse-os-version.sh $RPM_BUILD_ROOT/opt/os-discovery-tool/suse-os-version.sh
-install host-inv.yaml $RPM_BUILD_ROOT/opt/os-discovery-tool/host-inv.yaml
-install LICENSE $RPM_BUILD_ROOT/opt/os-discovery-tool/LICENSE
-install README.md $RPM_BUILD_ROOT/opt/os-discovery-tool/README.md
-install coreos-name.sh $RPM_BUILD_ROOT/opt/os-discovery-tool/coreos-name.sh
+install -d $RPM_BUILD_ROOT/opt/ucs-tool
+install debian-os-name.sh $RPM_BUILD_ROOT/opt/ucs-tool/debian-os-name.sh
+install debian-os-version.sh $RPM_BUILD_ROOT/opt/ucs-tool/debian-os-version.sh
+install fcdev.sh $RPM_BUILD_ROOT/opt/ucs-tool/fcdev.sh
+install fcdriver.sh $RPM_BUILD_ROOT/opt/ucs-tool/fcdriver.sh
+install fcversions.sh $RPM_BUILD_ROOT/opt/ucs-tool/fcversions.sh
+install gather_inventory_from_host.sh $RPM_BUILD_ROOT/opt/ucs-tool/gather_inventory_from_host.sh
+install gpudev.sh $RPM_BUILD_ROOT/opt/ucs-tool/gpudev.sh
+install gpudriver.sh $RPM_BUILD_ROOT/opt/ucs-tool/gpudriver.sh
+install gpuversions.sh $RPM_BUILD_ROOT/opt/ucs-tool/gpuversions.sh
+install netdev.sh $RPM_BUILD_ROOT/opt/ucs-tool/netdev.sh
+install netdriver.sh $RPM_BUILD_ROOT/opt/ucs-tool/netdriver.sh
+install netversions.sh $RPM_BUILD_ROOT/opt/ucs-tool/netversions.sh
+install osvendor-legacy.sh $RPM_BUILD_ROOT/opt/ucs-tool/osvendor-legacy.sh
+install osvendor.sh $RPM_BUILD_ROOT/opt/ucs-tool/osvendor.sh
+install redhat-os-name.sh $RPM_BUILD_ROOT/opt/ucs-tool/redhat-os-name.sh
+install send_inventory_to_imc.sh $RPM_BUILD_ROOT/opt/ucs-tool/send_inventory_to_imc.sh
+install storagedev.sh $RPM_BUILD_ROOT/opt/ucs-tool/storagedev.sh
+install storagedriver.sh $RPM_BUILD_ROOT/opt/ucs-tool/storagedriver.sh
+install storageversions.sh $RPM_BUILD_ROOT/opt/ucs-tool/storageversions.sh
+install rocky-os-name.sh $RPM_BUILD_ROOT/opt/ucs-tool/rocky-os-name.sh
+install oracle-os-name.sh $RPM_BUILD_ROOT/opt/ucs-tool/oracle-os-name.sh
+install oracle-os-version.sh $RPM_BUILD_ROOT/opt/ucs-tool/oracle-os-version.sh
+install suse-os-version.sh $RPM_BUILD_ROOT/opt/ucs-tool/suse-os-version.sh
+install host-inv.yaml $RPM_BUILD_ROOT/opt/ucs-tool/host-inv.yaml
+install LICENSE $RPM_BUILD_ROOT/opt/ucs-tool/LICENSE
+install README.md $RPM_BUILD_ROOT/opt/ucs-tool/README.md
+install coreos-name.sh $RPM_BUILD_ROOT/opt/ucs-tool/coreos-name.sh
 
 %post
-chmod 755 -R /opt/os-discovery-tool
+chmod 755 -R /opt/ucs-tool
 %define tempFile `mktemp`
 #store temp file name
 TEMP_FILE_NAME=%{tempFile}
 CRON_OUT_FILE=`crontab -l > $TEMP_FILE_NAME`
 ADD_TO_CRON=`echo "#Schedule the os inventory to imc:" >> $TEMP_FILE_NAME`
-ADD_TO_CRON=`echo "0 0 * * * /opt/os-discovery-tool/gather_inventory_from_host.sh & > /dev/null 2>&1 " >> $TEMP_FILE_NAME`
-ADD_TO_CRON=`echo "@reboot /opt/os-discovery-tool/gather_inventory_from_host.sh & > /dev/null 2>&1 " >> $TEMP_FILE_NAME`
+ADD_TO_CRON=`echo "0 0 * * * /opt/ucs-tool/gather_inventory_from_host.sh & > /dev/null 2>&1 " >> $TEMP_FILE_NAME`
+ADD_TO_CRON=`echo "@reboot /opt/ucs-tool/gather_inventory_from_host.sh & > /dev/null 2>&1 " >> $TEMP_FILE_NAME`
 ADD_TEMP_TO_CRON=`crontab $TEMP_FILE_NAME`
 rm -r -f $TEMP_FILE_NAME
 #To execute immediately after installation
-RUN_CMD=`/opt/os-discovery-tool/gather_inventory_from_host.sh & > /dev/null 2>&1`
+RUN_CMD=`/opt/ucs-tool/gather_inventory_from_host.sh & > /dev/null 2>&1`
 
 %postun
 TEMP_FILE_NAME=%{tempFile}
@@ -74,32 +74,32 @@ rm -r -f $TEMP_FILE_NAME
 
 %license LICENSE
 %files
-%dir /opt/os-discovery-tool
+%dir /opt/ucs-tool
 %defattr(-,root,root,-)
-/opt/os-discovery-tool/debian-os-name.sh
-/opt/os-discovery-tool/debian-os-version.sh
-/opt/os-discovery-tool/fcdev.sh
-/opt/os-discovery-tool/fcdriver.sh
-/opt/os-discovery-tool/fcversions.sh
-/opt/os-discovery-tool/gather_inventory_from_host.sh
-/opt/os-discovery-tool/gpudev.sh
-/opt/os-discovery-tool/gpudriver.sh
-/opt/os-discovery-tool/gpuversions.sh
-/opt/os-discovery-tool/netdev.sh
-/opt/os-discovery-tool/netdriver.sh
-/opt/os-discovery-tool/netversions.sh
-/opt/os-discovery-tool/osvendor-legacy.sh
-/opt/os-discovery-tool/osvendor.sh
-/opt/os-discovery-tool/redhat-os-name.sh
-/opt/os-discovery-tool/send_inventory_to_imc.sh
-/opt/os-discovery-tool/storagedev.sh
-/opt/os-discovery-tool/storagedriver.sh
-/opt/os-discovery-tool/storageversions.sh
-/opt/os-discovery-tool/rocky-os-name.sh
-/opt/os-discovery-tool/oracle-os-name.sh
-/opt/os-discovery-tool/oracle-os-version.sh
-/opt/os-discovery-tool/suse-os-version.sh
-/opt/os-discovery-tool/host-inv.yaml
-/opt/os-discovery-tool/LICENSE
-/opt/os-discovery-tool/README.md
-/opt/os-discovery-tool/coreos-name.sh
+/opt/ucs-tool/debian-os-name.sh
+/opt/ucs-tool/debian-os-version.sh
+/opt/ucs-tool/fcdev.sh
+/opt/ucs-tool/fcdriver.sh
+/opt/ucs-tool/fcversions.sh
+/opt/ucs-tool/gather_inventory_from_host.sh
+/opt/ucs-tool/gpudev.sh
+/opt/ucs-tool/gpudriver.sh
+/opt/ucs-tool/gpuversions.sh
+/opt/ucs-tool/netdev.sh
+/opt/ucs-tool/netdriver.sh
+/opt/ucs-tool/netversions.sh
+/opt/ucs-tool/osvendor-legacy.sh
+/opt/ucs-tool/osvendor.sh
+/opt/ucs-tool/redhat-os-name.sh
+/opt/ucs-tool/send_inventory_to_imc.sh
+/opt/ucs-tool/storagedev.sh
+/opt/ucs-tool/storagedriver.sh
+/opt/ucs-tool/storageversions.sh
+/opt/ucs-tool/rocky-os-name.sh
+/opt/ucs-tool/oracle-os-name.sh
+/opt/ucs-tool/oracle-os-version.sh
+/opt/ucs-tool/suse-os-version.sh
+/opt/ucs-tool/host-inv.yaml
+/opt/ucs-tool/LICENSE
+/opt/ucs-tool/README.md
+/opt/ucs-tool/coreos-name.sh

--- a/send_inventory_to_imc.sh
+++ b/send_inventory_to_imc.sh
@@ -3,7 +3,7 @@
 
 export PATH=$PATH:/sbin:/usr/sbin
 ipmitoolcmd=`which ipmitool`
-installationPath="/opt/os-discovery-tool"
+installationPath="/opt/ucs-tool"
 inventoryfilename=$installationPath/"host-inv.yaml"
 
 if [ $(stat -c %s $inventoryfilename) -ge 65535 ] ; then


### PR DESCRIPTION
Changes:
1. Renamed output package name from os-discovery-tool to ucs-tool
2. Installation directory changed from /opt/os-discovery-tool to /opt/ucs-tool

Test results:
<img width="1104" height="143" alt="ucs-tool-rename1" src="https://github.com/user-attachments/assets/3392353b-fb41-4430-953e-0f35806c056e" />
<img width="1306" height="703" alt="ucs-tool-rename2" src="https://github.com/user-attachments/assets/f906fef7-756d-4b88-93d4-295eff6ada69" />

