### PR TITLE
Nvidia GPU passthru support

### DIFF
--- a/gpudriver.sh
+++ b/gpudriver.sh
@@ -22,6 +22,12 @@ for pciaddress in $(${lshwcmd} -C Display 2>/dev/null | grep "pci@" | awk -F":" 
          classcode=$(${lspcicmd} -v -s ${pciaddress} | grep -i "VGA compatible controller\|3d controller" | awk -F":" '{print $2}' | awk -F" " '{print $2" "$3" "$4}' | xargs)
          driver=$(${lspcicmd} -v -s ${pciaddress} | grep "Kernel driver" | awk -F":" '{print $2}' | xargs);
 
+            # check if GPU is in passthru mode
+            if [[ "$driver" == "vfio-pci" ]]; then
+                echo "nvidia(passthrough)"
+                continue
+            fi
+
          # Check if the nvidia-smi drivers are installed correctly
          if ! ([[ $nvidiasmicmd =~ $invalid || -z "$nvidiasmicmd" ]]);
          then
@@ -67,11 +73,7 @@ for pciaddress in $(${lshwcmd} -C Display 2>/dev/null | grep "pci@" | awk -F":" 
               fi
           fi
 
-         # check if GPU is in passthru mode
-         elif [[ ($osvendor == "rhel") || ($osvendor == "red hat") ]] && [[ ($driver == "vfio-pci") ]];
-         then
-            continue
-         fi
+            fi
     elif [[ ${displaydevice,,} =~ 'amd' ]]; then
         if [ -e $amdcmdpath ]; then
 	    echo "rocm"

--- a/gpuversions.sh
+++ b/gpuversions.sh
@@ -22,6 +22,12 @@ for pciaddress in $(${lshwcmd} -C Display 2>/dev/null | grep "pci@" | awk -F":" 
          classcode=$(${lspcicmd} -v -s ${pciaddress} | grep -i "VGA compatible controller\|3d controller" | awk -F":" '{print $2}' | awk -F" " '{print $2" "$3" "$4}' | xargs)
          driver=$(${lspcicmd} -v -s ${pciaddress} | grep "Kernel driver" | awk -F":" '{print $2}' | xargs);
 
+            # check if GPU is in passthru mode
+            if [[ "$driver" == "vfio-pci" ]]; then
+                echo ""
+                continue
+            fi
+
          # Check if the nvidia-smi drivers are installed correctly
          if ! ([[ $nvidiasmicmd =~ $invalid || -z "$nvidiasmicmd" ]]);
          then
@@ -67,11 +73,7 @@ for pciaddress in $(${lshwcmd} -C Display 2>/dev/null | grep "pci@" | awk -F":" 
               fi
           fi
 
-         # check if GPU is in passthru mode
-         elif [[ ($osvendor == "rhel") || ($osvendor == "red hat") ]] && [[ ($driver == "vfio-pci") ]];
-         then
-            continue
-         fi
+            fi
     elif [[ ${displaydevice,,} =~ 'amd' ]]; then
         if [ -e $amdcmdpath ]; then
 	    cat $amdcmdpath


### PR DESCRIPTION
Earlier we do not send any details when the GPU is configured in passthru mode, with the current changes we are going to send the driver name as "nvidia(passthrough)".

Sample host-inv.yaml output:
```
 -kv:
  key: os.driver.7.name
  value: nvidia(passthrough)
 -kv:
  key: os.driver.7.version
  value:
 -kv:
  key: os.driver.7.description
  value: NVIDIA Corporation Device 1851
```

<img width="621" height="139" alt="Screenshot 2026-06-10 at 1 37 57 PM" src="https://github.com/user-attachments/assets/6ade094c-53a9-46d1-be95-ae793321a7ec" />
