### PR TITLE
Updated RPM packaging for broader distro compatibility by switching payload compression to gzip and standardized Bash shebangs

### DIFF
--- a/coreos-name.sh
+++ b/coreos-name.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2025 Cisco Systems, Inc. All rights reserved.
 
 version=`cat /etc/*-release | grep 'VERSION_ID\=' | head -n1 | awk -F'=' '{print $2}'| awk -F'"' '{print $2}'`

--- a/debian-os-name.sh
+++ b/debian-os-name.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2025 Cisco Systems, Inc. All rights reserved.
 
 cat /etc/*-release | grep 'PRETTY_NAME\=' | head -n1 | awk -F"=" '{print $2}' | xargs | awk '{print $1" "$2" "$3}'

--- a/debian-os-version.sh
+++ b/debian-os-version.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2025 Cisco Systems, Inc. All rights reserved.
 
 cat /etc/*-release | grep 'PRETTY_NAME\=' | head -n1 | awk -F'=' '{print $2}' | awk -F'"' '{print $2}' | awk -F" " '{print $1" Server "$2" "$3}'

--- a/fcdev.sh
+++ b/fcdev.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2025 Cisco Systems, Inc. All rights reserved.
 
 export PATH=$PATH:/sbin:/usr/sbin

--- a/fcdriver.sh
+++ b/fcdriver.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2025 Cisco Systems, Inc. All rights reserved.
 
 export PATH=$PATH:/sbin:/usr/sbin

--- a/fcversions.sh
+++ b/fcversions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2025 Cisco Systems, Inc. All rights reserved.
 
 export PATH=$PATH:/sbin:/usr/sbin

--- a/gather_inventory_from_host.sh
+++ b/gather_inventory_from_host.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2025 Cisco Systems, Inc. All rights reserved.
 
 export PATH=$PATH:/sbin:/usr/sbin

--- a/gpudev.sh
+++ b/gpudev.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2025 Cisco Systems, Inc. All rights reserved.
 
 export PATH=$PATH:/sbin:/usr/sbin

--- a/gpudriver.sh
+++ b/gpudriver.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2025 Cisco Systems, Inc. All rights reserved.
 
 export PATH=$PATH:/sbin:/usr/sbin

--- a/gpuversions.sh
+++ b/gpuversions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2025 Cisco Systems, Inc. All rights reserved.
 
 export PATH=$PATH:/sbin:/usr/sbin

--- a/netdev.sh
+++ b/netdev.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2025 Cisco Systems, Inc. All rights reserved.
 
 export PATH=$PATH:/sbin:/usr/sbin

--- a/netdriver.sh
+++ b/netdriver.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2025 Cisco Systems, Inc. All rights reserved.
 
 export PATH=$PATH:/sbin:/usr/sbin

--- a/netversions.sh
+++ b/netversions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2025 Cisco Systems, Inc. All rights reserved.
 
 export PATH=$PATH:/sbin:/usr/sbin

--- a/oracle-os-name.sh
+++ b/oracle-os-name.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2025 Cisco Systems, Inc. All rights reserved.
 
 cat /etc/*-release | grep NAME | head -n1 | awk -F"=" '{print $2}' | xargs

--- a/oracle-os-version.sh
+++ b/oracle-os-version.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2025 Cisco Systems, Inc. All rights reserved.
 
 kernel=$(uname -a | awk '{print $3}' | awk -F"." '{print $(NF-1)}')

--- a/os-discovery-tool-linux.spec
+++ b/os-discovery-tool-linux.spec
@@ -6,8 +6,9 @@ Summary:        The Cisco Intersight ucs-tool is used to collect operating syste
 License:        Apache-2.0
 Source0:        %{name}-%{version}.tar.gz
 Requires:       ipmitool
-# Filter auto-generated shebang path deps; keep package-level bash requirement for portability.
-%global __requires_exclude ^(/usr/bin/bash|/bin/bash)$
+Requires:       bash
+# Preserve env-based shebangs (#!/usr/bin/env bash) for cross-distro compatibility.
+%global __brp_mangle_shebangs %{nil}
 
 %description
 The Cisco Intersight ucs-tool is used to collect operating system and driver information for Hardware Compliance Validation.

--- a/os-discovery-tool-linux.spec
+++ b/os-discovery-tool-linux.spec
@@ -5,12 +5,13 @@ Vendor:         Cisco Systems, Inc.
 Summary:        The Cisco Intersight ucs-tool is used to collect operating system and driver information for Hardware Compliance Validation.
 License:        Apache-2.0
 Source0:        %{name}-%{version}.tar.gz
-Requires:       bash, ipmitool
+Requires:       /bin/bash, ipmitool
 
 %description
 The Cisco Intersight ucs-tool is used to collect operating system and driver information for Hardware Compliance Validation.
 
 %global debug_package %{nil}
+%define _binary_payload w9.gzdio
 
 %prep
 %setup -q

--- a/os-discovery-tool-linux.spec
+++ b/os-discovery-tool-linux.spec
@@ -5,7 +5,9 @@ Vendor:         Cisco Systems, Inc.
 Summary:        The Cisco Intersight ucs-tool is used to collect operating system and driver information for Hardware Compliance Validation.
 License:        Apache-2.0
 Source0:        %{name}-%{version}.tar.gz
-Requires:       ipmitool
+Requires:       bash, ipmitool
+# Filter auto-generated shebang path deps; keep package-level bash requirement for portability.
+%global __requires_exclude ^(/usr/bin/bash|/bin/bash)$
 
 %description
 The Cisco Intersight ucs-tool is used to collect operating system and driver information for Hardware Compliance Validation.

--- a/os-discovery-tool-linux.spec
+++ b/os-discovery-tool-linux.spec
@@ -5,7 +5,7 @@ Vendor:         Cisco Systems, Inc.
 Summary:        The Cisco Intersight ucs-tool is used to collect operating system and driver information for Hardware Compliance Validation.
 License:        Apache-2.0
 Source0:        %{name}-%{version}.tar.gz
-Requires:       /bin/bash, ipmitool
+Requires:       ipmitool
 
 %description
 The Cisco Intersight ucs-tool is used to collect operating system and driver information for Hardware Compliance Validation.

--- a/os-discovery-tool-linux.spec
+++ b/os-discovery-tool-linux.spec
@@ -6,6 +6,8 @@ Summary:        The Cisco Intersight ucs-tool is used to collect operating syste
 License:        Apache-2.0
 Source0:        %{name}-%{version}.tar.gz
 Requires:       ipmitool
+# Filter auto-generated shebang path deps; keep package-level bash requirement for portability.
+%global __requires_exclude ^(/usr/bin/bash|/bin/bash)$
 
 %description
 The Cisco Intersight ucs-tool is used to collect operating system and driver information for Hardware Compliance Validation.

--- a/os-discovery-tool-linux.spec
+++ b/os-discovery-tool-linux.spec
@@ -5,9 +5,7 @@ Vendor:         Cisco Systems, Inc.
 Summary:        The Cisco Intersight ucs-tool is used to collect operating system and driver information for Hardware Compliance Validation.
 License:        Apache-2.0
 Source0:        %{name}-%{version}.tar.gz
-Requires:       bash, ipmitool
-# Filter auto-generated shebang path deps; keep package-level bash requirement for portability.
-%global __requires_exclude ^(/usr/bin/bash|/bin/bash)$
+Requires:       ipmitool
 
 %description
 The Cisco Intersight ucs-tool is used to collect operating system and driver information for Hardware Compliance Validation.

--- a/osvendor-legacy.sh
+++ b/osvendor-legacy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2025 Cisco Systems, Inc. All rights reserved.
 
 cat /etc/*-release | grep "Linux" | head -n 1 | awk '{print $1" "$2}'

--- a/osvendor.sh
+++ b/osvendor.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2025 Cisco Systems, Inc. All rights reserved.
 
 releasefile="/etc/*-release"

--- a/proxmox-os-name.sh
+++ b/proxmox-os-name.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2025 Cisco Systems, Inc. All rights reserved.
 
 export PATH=$PATH:/sbin:/usr/sbin

--- a/redhat-os-name.sh
+++ b/redhat-os-name.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2025 Cisco Systems, Inc. All rights reserved.
 
 redhat_version=$(cat /etc/*-release | grep ^VERSION | head -n1 | awk -F"=" '{print $2}' | xargs | awk -F'[ ]' '{print $1}' | xargs)

--- a/rocky-os-name.sh
+++ b/rocky-os-name.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2025 Cisco Systems, Inc. All rights reserved.
 
 FILE=/etc/rocky-release

--- a/send_inventory_to_imc.sh
+++ b/send_inventory_to_imc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2025 Cisco Systems, Inc. All rights reserved.
 
 export PATH=$PATH:/sbin:/usr/sbin

--- a/storagedev.sh
+++ b/storagedev.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2025 Cisco Systems, Inc. All rights reserved.
 
 export PATH=$PATH:/sbin:/usr/sbin

--- a/storagedriver.sh
+++ b/storagedriver.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2025 Cisco Systems, Inc. All rights reserved.
 
 export PATH=$PATH:/sbin:/usr/sbin

--- a/storageversions.sh
+++ b/storageversions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2025 Cisco Systems, Inc. All rights reserved.
 
 export PATH=$PATH:/sbin:/usr/sbin

--- a/suse-os-version.sh
+++ b/suse-os-version.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2025 Cisco Systems, Inc. All rights reserved.
 
 cat /etc/*-release | grep PRETTY_NAME | awk -F"=" '{print $2}' | xargs


### PR DESCRIPTION
The spec now avoids zstd-dependent payloads for SLES compatibility, and all Bash scripts were normalized to env-based shebangs to improve cross-distribution reliability without changing runtime logic.