### PR TITLE
Emulex HBA version missing on inventory

### DIFF
--- a/netdriver.sh
+++ b/netdriver.sh
@@ -18,5 +18,12 @@ done
 # support for QLogic and Emulex HBA Adapter
 ${lspcicmd} -nn | grep -Ei 'hba|host bus adapter|fibre channel' | awk -F" " '{print $1}' | while read pciaddress;
 do
-    ${lspcicmd} -v -s ${pciaddress} | grep "Kernel driver" | awk -F":" '{print $2}'| xargs;
+    hbaoutput=$("$lspcicmd" -v -s "$pciaddress")
+    hba_kernel_driver=$(echo "$hbaoutput" | grep "Kernel driver" | awk '{print $NF}')
+    hba_kernel_modules=$(echo "$hbaoutput" | grep "Kernel modules" | awk '{print $NF}')
+    if [ -n "$hba_kernel_driver" ]; then
+        echo $hba_kernel_driver
+    else
+        echo $hba_kernel_modules
+    fi
 done

--- a/netversions.sh
+++ b/netversions.sh
@@ -26,12 +26,19 @@ done
 # support for QLogic and Emulex HBA Adapter
 ${lspcicmd} -nn | grep -Ei 'hba|host bus adapter|fibre channel' | awk -F" " '{print $1}' | while read pciaddress;
 do
-    hbaversionstring=`${lspcicmd} -v -s ${pciaddress} | grep "Kernel driver" | awk -F":" '{print $2}' | xargs ${modinfocmd} 2>/dev/null | grep ^version: | awk '{print $2}'`
-    if [ -z "${hbaversionstring}" ]
-    then
-        echo `${lspcicmd} -v -s ${pciaddress} | grep "Kernel driver" | awk -F":" '{print $2}'| \
-    xargs ${modinfocmd} 2>/dev/null | grep ^vermagic: | awk '{print $2}'`
+    hbaoutput=$("$lspcicmd" -v -s "$pciaddress")
+    hba_kernel_driver=$(echo "$hbaoutput" | grep "Kernel driver" | awk '{print $NF}')
+    hba_kernel_modules=$(echo "$hbaoutput" | grep "Kernel modules" | awk '{print $NF}')
+    if [ -n "$hba_kernel_driver" ]; then
+        hba_kernel_info=$hba_kernel_driver
     else
-        echo ${hbaversionstring}
+        hba_kernel_info=$hba_kernel_modules
+    fi
+    hbaversionstring=$(${modinfocmd} $hba_kernel_info 2>/dev/null | grep ^version: | head -n1 | awk '{print $2}' | xargs)
+    hbavermagic=$(${modinfocmd} $hba_kernel_info 2>/dev/null | grep ^vermagic: | awk '{print $2}' | xargs)
+    if [ -n "${hbaversionstring}" ]; then
+        echo $hbaversionstring
+    else
+        echo $hbavermagic
     fi
 done


### PR DESCRIPTION
Root cause: key "Kernel driver" was missing in the `lspci` command output, instead the data was populated on the key "Kernel modules"

Fix: Added a fallback condition to fetch driver name from "Kernel modules" key if "Kernel driver" was not present.
sample host-inv.yaml output:
```
- kv:
  key: os.driver.8.description
  value: Emulex Corporation LPe35002-M2 2-Port 32Gb Fibre Channel Adapter
- kv:
  key: os.driver.8.version
  value: 0:14.4.725.14
- kv:
  key: os.driver.8.name
  value: lpfc
```
<img width="2194" height="1130" alt="12_46_00" src="https://github.com/user-attachments/assets/5ae67494-8fa6-4e7f-b8dd-b531e5ee0d53" />
